### PR TITLE
PYAS 自保护增强

### DIFF
--- a/Plugins/Filter/DriverCommon.h
+++ b/Plugins/Filter/DriverCommon.h
@@ -116,6 +116,8 @@ typedef struct _DRIVER_DATA {
     LARGE_INTEGER Cookie;
     KSPIN_LOCK PortMutex;
     KSPIN_LOCK TrackerMutex;
+    KSPIN_LOCK PidLock;
+    BOOLEAN Initialized;
     EX_RUNDOWN_REF PortRundown;
 } DRIVER_DATA, * PDRIVER_DATA;
 
@@ -150,6 +152,9 @@ VOID RemoveDynamicWhitelist(PUNICODE_STRING RuleStr);
 VOID ImageLoadNotify(PUNICODE_STRING FullImageName, HANDLE ProcessId, PIMAGE_INFO ImageInfo);
 
 NTSTATUS GetProcessImageName(HANDLE ProcessId, PUNICODE_STRING* ImageName);
+
+ULONG SafeGetPyasPid();
+VOID SafeSetPyasPid(ULONG Pid);
 
 BOOLEAN IsProcessTrusted(HANDLE ProcessId);
 BOOLEAN IsTargetProtected(HANDLE ProcessId);

--- a/Plugins/Filter/DriverEntry.cpp
+++ b/Plugins/Filter/DriverEntry.cpp
@@ -51,6 +51,8 @@ static NTSTATUS DriverUnload(FLT_FILTER_UNLOAD_FLAGS Flags) {
     UnloadRules();
     UninitializeRulesEngine();
 
+    GlobalData.Initialized = FALSE;
+
     return STATUS_SUCCESS;
 }
 
@@ -92,7 +94,7 @@ static NTSTATUS PortConnect(PFLT_PORT ClientPort, PVOID ServerPortCookie, PVOID 
     KeAcquireSpinLock(&GlobalData.PortMutex, &OldIrql);
 
     GlobalData.ClientPort = ClientPort;
-    GlobalData.PyasPid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
+    SafeSetPyasPid((ULONG)(ULONG_PTR)PsGetCurrentProcessId());
     GlobalData.PyasProcess = PsGetCurrentProcess();
 
     ExReInitializeRundownProtection(&GlobalData.PortRundown);
@@ -109,7 +111,7 @@ static VOID PortDisconnect(PVOID ConnectionCookie) {
     KeAcquireSpinLock(&GlobalData.PortMutex, &OldIrql);
 
     GlobalData.ClientPort = NULL;
-    GlobalData.PyasPid = 0;
+    SafeSetPyasPid(0);
     GlobalData.PyasProcess = NULL;
 
     KeReleaseSpinLock(&GlobalData.PortMutex, OldIrql);
@@ -153,6 +155,8 @@ extern "C" NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING Reg
     GlobalData.DriverObject = DriverObject;
     KeInitializeSpinLock(&GlobalData.PortMutex);
     KeInitializeSpinLock(&GlobalData.TrackerMutex);
+    KeInitializeSpinLock(&GlobalData.PidLock);
+    GlobalData.Initialized = TRUE;
 
     ExInitializeRundownProtection(&GlobalData.PortRundown);
 

--- a/Plugins/Filter/ProtectProcess.cpp
+++ b/Plugins/Filter/ProtectProcess.cpp
@@ -1,8 +1,10 @@
 #include "DriverCommon.h"
 
 static PVOID ObRegistrationHandle = NULL;
-static OB_CALLBACK_REGISTRATION ObRegistration;
-static OB_OPERATION_REGISTRATION ObCallbacks[2];
+static OB_CALLBACK_REGISTRATION ObRegistration = {0};
+static OB_OPERATION_REGISTRATION ObCallbacks[2] = {0};
+static KSPIN_LOCK ObDataLock = {0};
+static BOOLEAN ObDataInitialized = FALSE;
 
 static BOOLEAN IsSystemImage(PUNICODE_STRING FullImageName) {
     if (!FullImageName || !FullImageName->Buffer) return FALSE;
@@ -57,6 +59,11 @@ static BOOLEAN IsCriticalSystemProcess(HANDLE ProcessId) {
             WildcardMatch(L"*\\Windows\\System32\\smss.exe", imageFileName->Buffer, imageFileName->Length)) {
             isCritical = TRUE;
         }
+    }
+
+    // 修复：只有在 imageFileName->Buffer 非空时才释放
+    if (imageFileName) {
+        if (imageFileName->Buffer) ExFreePool(imageFileName->Buffer);
         ExFreePool(imageFileName);
     }
 
@@ -77,15 +84,18 @@ static BOOLEAN IsBlacklistedAdminTool(HANDLE ProcessId) {
 
     status = SeLocateProcessImageName(Process, &imageFileName);
 
-    if (NT_SUCCESS(status) && imageFileName) {
-        if (imageFileName->Buffer) {
-            if (WildcardMatch(L"*Taskmgr.exe", imageFileName->Buffer, imageFileName->Length) ||
-                WildcardMatch(L"*taskkill.exe", imageFileName->Buffer, imageFileName->Length) ||
-                WildcardMatch(L"*ProcessHacker.exe", imageFileName->Buffer, imageFileName->Length) ||
-                WildcardMatch(L"*procmon.exe", imageFileName->Buffer, imageFileName->Length)) {
-                isBlacklisted = TRUE;
-            }
+    if (NT_SUCCESS(status) && imageFileName && imageFileName->Buffer) {
+        if (WildcardMatch(L"*Taskmgr.exe", imageFileName->Buffer, imageFileName->Length) ||
+            WildcardMatch(L"*taskkill.exe", imageFileName->Buffer, imageFileName->Length) ||
+            WildcardMatch(L"*ProcessHacker.exe", imageFileName->Buffer, imageFileName->Length) ||
+            WildcardMatch(L"*procmon.exe", imageFileName->Buffer, imageFileName->Length)) {
+            isBlacklisted = TRUE;
         }
+    }
+
+    // 修复：只有在 imageFileName->Buffer 非空时才释放
+    if (imageFileName) {
+        if (imageFileName->Buffer) ExFreePool(imageFileName->Buffer);
         ExFreePool(imageFileName);
     }
 
@@ -105,20 +115,39 @@ static OB_PREOP_CALLBACK_STATUS PreOpenProcess(PVOID RegistrationContext, POB_PR
     HANDLE SourcePid = PsGetCurrentProcessId();
 
     if (SourcePid == TargetPid) return OB_PREOP_SUCCESS;
-    if ((ULONG)(ULONG_PTR)SourcePid == GlobalData.PyasPid) return OB_PREOP_SUCCESS;
+    if ((ULONG)(ULONG_PTR)SourcePid == SafeGetPyasPid()) return OB_PREOP_SUCCESS;
     if (SourcePid == (HANDLE)4) return OB_PREOP_SUCCESS;
 
     if (IsTargetProtected(TargetPid)) {
         if (IsCriticalSystemProcess(SourcePid)) return OB_PREOP_SUCCESS;
 
-        BOOLEAN bIsTrusted = IsProcessTrusted(SourcePid);
-
-        if (bIsTrusted) {
-            if (IsBlacklistedAdminTool(SourcePid)) {
-                bIsTrusted = FALSE;
-            }
+        // 优先检查黑名单（在 PASSIVE_LEVEL 时）
+        BOOLEAN isBlacklisted = FALSE;
+        if (KeGetCurrentIrql() == PASSIVE_LEVEL) {
+            isBlacklisted = IsBlacklistedAdminTool(SourcePid);
         }
 
+        // 黑名单进程直接阻止，不检查信任
+        if (isBlacklisted) {
+            ACCESS_MASK DenyMask = PROCESS_TERMINATE |
+                PROCESS_VM_OPERATION |
+                PROCESS_VM_WRITE |
+                PROCESS_CREATE_THREAD |
+                PROCESS_VM_READ |
+                PROCESS_DUP_HANDLE |
+                PROCESS_SUSPEND_RESUME |
+                PROCESS_SET_INFORMATION |
+                PROCESS_SET_QUOTA;
+
+            OperationInformation->Parameters->CreateHandleInformation.DesiredAccess &= (ACCESS_MASK)(~DenyMask);
+
+            if (OperationInformation->Operation == OB_OPERATION_HANDLE_DUPLICATE) {
+                OperationInformation->Parameters->DuplicateHandleInformation.DesiredAccess &= (ACCESS_MASK)(~DenyMask);
+            }
+            return OB_PREOP_SUCCESS;
+        }
+
+        BOOLEAN bIsTrusted = IsProcessTrusted(SourcePid);
         if (bIsTrusted) return OB_PREOP_SUCCESS;
 
         ACCESS_MASK DenyMask = PROCESS_TERMINATE |
@@ -156,20 +185,35 @@ static OB_PREOP_CALLBACK_STATUS PreOpenThread(PVOID RegistrationContext, POB_PRE
     HANDLE SourcePid = PsGetCurrentProcessId();
 
     if (SourcePid == TargetPid) return OB_PREOP_SUCCESS;
-    if ((ULONG)(ULONG_PTR)SourcePid == GlobalData.PyasPid) return OB_PREOP_SUCCESS;
+    if ((ULONG)(ULONG_PTR)SourcePid == SafeGetPyasPid()) return OB_PREOP_SUCCESS;
     if (SourcePid == (HANDLE)4) return OB_PREOP_SUCCESS;
 
     if (IsTargetProtected(TargetPid)) {
         if (IsCriticalSystemProcess(SourcePid)) return OB_PREOP_SUCCESS;
 
-        BOOLEAN bIsTrusted = IsProcessTrusted(SourcePid);
-
-        if (bIsTrusted) {
-            if (IsBlacklistedAdminTool(SourcePid)) {
-                bIsTrusted = FALSE;
-            }
+        // 优先检查黑名单（在 PASSIVE_LEVEL 时）
+        BOOLEAN isBlacklisted = FALSE;
+        if (KeGetCurrentIrql() == PASSIVE_LEVEL) {
+            isBlacklisted = IsBlacklistedAdminTool(SourcePid);
         }
 
+        // 黑名单进程直接阻止，不检查信任
+        if (isBlacklisted) {
+            ACCESS_MASK DenyMask = THREAD_TERMINATE |
+                THREAD_SUSPEND_RESUME |
+                THREAD_SET_CONTEXT |
+                THREAD_SET_INFORMATION |
+                THREAD_SET_THREAD_TOKEN;
+
+            OperationInformation->Parameters->CreateHandleInformation.DesiredAccess &= (ACCESS_MASK)(~DenyMask);
+
+            if (OperationInformation->Operation == OB_OPERATION_HANDLE_DUPLICATE) {
+                OperationInformation->Parameters->DuplicateHandleInformation.DesiredAccess &= (ACCESS_MASK)(~DenyMask);
+            }
+            return OB_PREOP_SUCCESS;
+        }
+
+        BOOLEAN bIsTrusted = IsProcessTrusted(SourcePid);
         if (bIsTrusted) return OB_PREOP_SUCCESS;
 
         ACCESS_MASK DenyMask = THREAD_TERMINATE |
@@ -190,6 +234,9 @@ static OB_PREOP_CALLBACK_STATUS PreOpenThread(PVOID RegistrationContext, POB_PRE
 
 NTSTATUS InitializeProcessProtection() {
     static UNICODE_STRING Altitude = RTL_CONSTANT_STRING(L"320000.PYAS.Ob");
+
+    KeInitializeSpinLock(&ObDataLock);
+    ObDataInitialized = TRUE;
 
     ObCallbacks[0].ObjectType = PsProcessType;
     ObCallbacks[0].Operations = OB_OPERATION_HANDLE_CREATE | OB_OPERATION_HANDLE_DUPLICATE;
@@ -219,6 +266,8 @@ NTSTATUS InitializeProcessProtection() {
 }
 
 VOID UninitializeProcessProtection() {
+    ObDataInitialized = FALSE;
+
     if (ObRegistrationHandle) {
         ObUnRegisterCallbacks(ObRegistrationHandle);
         ObRegistrationHandle = NULL;

--- a/Plugins/Filter/ProtectRules.cpp
+++ b/Plugins/Filter/ProtectRules.cpp
@@ -36,6 +36,33 @@ static PRULE_NODE g_FileProtectedPaths = NULL;
 static PRULE_NODE g_FileExceptionPaths = NULL;
 static PRULE_NODE g_FileRansomExts = NULL;
 
+// 安全的 PyasPid 读写函数（带锁保护）
+ULONG SafeGetPyasPid() {
+    if (KeGetCurrentIrql() >= DISPATCH_LEVEL) {
+        // 高 IRQL 时直接读取（避免自旋锁死锁）
+        // 64位系统上读取 ULONG 是原子的
+        return GlobalData.PyasPid;
+    }
+
+    KIRQL OldIrql;
+    KeAcquireSpinLock(&GlobalData.PidLock, &OldIrql);
+    ULONG Pid = GlobalData.PyasPid;
+    KeReleaseSpinLock(&GlobalData.PidLock, OldIrql);
+    return Pid;
+}
+
+VOID SafeSetPyasPid(ULONG Pid) {
+    if (KeGetCurrentIrql() >= DISPATCH_LEVEL) {
+        // 高 IRQL 时无法获取锁，降级处理
+        return;
+    }
+
+    KIRQL OldIrql;
+    KeAcquireSpinLock(&GlobalData.PidLock, &OldIrql);
+    GlobalData.PyasPid = Pid;
+    KeReleaseSpinLock(&GlobalData.PidLock, OldIrql);
+}
+
 const PCWSTR Helper_NaturallyCompressedExtensions[] = {
     L".zip", L".7z", L".rar", L".tar", L".gz",
     L".jpg", L".jpeg", L".png", L".webp", L".gif",
@@ -511,7 +538,8 @@ static BOOLEAN IsWindowsSystemApp(PCWSTR Buffer, USHORT Length) {
 }
 
 BOOLEAN IsProcessTrusted(HANDLE ProcessId) {
-    if ((ULONG)(ULONG_PTR)ProcessId == GlobalData.PyasPid) return TRUE;
+    ULONG PyasPid = SafeGetPyasPid();
+    if ((ULONG)(ULONG_PTR)ProcessId == PyasPid) return TRUE;
     if (ProcessId == (HANDLE)4) return TRUE;
 
     PEPROCESS Process = NULL;
@@ -598,7 +626,8 @@ update_cache:
 
 BOOLEAN IsTargetProtected(HANDLE ProcessId) {
     // 检查是否为已连接的 PYAS 进程
-    if ((ULONG)(ULONG_PTR)ProcessId == GlobalData.PyasPid) return TRUE;
+    ULONG PyasPid = SafeGetPyasPid();
+    if ((ULONG)(ULONG_PTR)ProcessId == PyasPid) return TRUE;
 
     // 额外检查：通过进程路径匹配保护规则（后备保护机制）
     if (KeGetCurrentIrql() != PASSIVE_LEVEL) return FALSE;


### PR DESCRIPTION
任务管理器通过匹配 Rule_Process_TrustedPaths 中的 *\\Windows\\* 规则被误判为可信进程，导致黑名单检查失效。